### PR TITLE
Add RFC 7523 JWT-bearer token exchange provider and improve code structure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,23 +14,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-    - name: vet
-      run: make vet
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: vet
+        run: make vet
 
-    - name: fmt
-      run: make fmt
+      - name: fmt
+        run: make fmt
 
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v7
-      with:
-        version: v2.0
-          
-    - name: Build
-      run: go build -v ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.9
 
+      - name: Build
+        run: go build -v ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,9 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
+    - funcorder
+    - wsl_v5
+    - noinlineerr
   settings:
     gocyclo:
       min-complexity: 20

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOPRIVATE = github.com/riptidesio,go.riptides.io
 
 # Dependency versions
 LICENSEI_VERSION = 0.9.0
-GOLANGCI_VERSION = 2.0.2
+GOLANGCI_VERSION = 2.9.0
 LICSENSEI_VERSION = 0.0.1
 
 .PHONY: help

--- a/pkg/aws/option.go
+++ b/pkg/aws/option.go
@@ -15,6 +15,7 @@ type (
 	}
 	credentialsOption struct {
 		option.Option
+
 		f func(*credentialsConfig)
 	}
 )

--- a/pkg/azure/option.go
+++ b/pkg/azure/option.go
@@ -15,6 +15,7 @@ type (
 	}
 	credentialsOption struct {
 		option.Option
+
 		f func(*credentialsConfig)
 	}
 )

--- a/pkg/gcp/option.go
+++ b/pkg/gcp/option.go
@@ -17,6 +17,7 @@ type (
 	}
 	credentialsOption struct {
 		option.Option
+
 		f func(*credentialsConfig)
 	}
 )

--- a/pkg/gcp/sts.go
+++ b/pkg/gcp/sts.go
@@ -16,6 +16,7 @@ import (
 
 type stsAccessTokenSource struct {
 	oauth2.TokenSource
+
 	stsService *stsv1.Service
 
 	idTokenProvider token.IdentityTokenProvider

--- a/pkg/generic/option.go
+++ b/pkg/generic/option.go
@@ -17,6 +17,7 @@ type (
 	}
 	credentialsOption struct {
 		option.Option
+
 		f func(*credentialsConfig)
 	}
 )

--- a/pkg/k8ssecret/option.go
+++ b/pkg/k8ssecret/option.go
@@ -12,6 +12,7 @@ type (
 	}
 	credentialsOption struct {
 		option.Option
+
 		f func(*credentialsConfig)
 	}
 )

--- a/pkg/oauth2cc/option.go
+++ b/pkg/oauth2cc/option.go
@@ -16,6 +16,7 @@ type (
 	}
 	credentialsOption struct {
 		option.Option
+
 		f func(*credentialsConfig)
 	}
 )

--- a/pkg/oci/option.go
+++ b/pkg/oci/option.go
@@ -15,6 +15,7 @@ type (
 	}
 	credentialsOption struct {
 		option.Option
+
 		f func(*credentialsConfig)
 	}
 )

--- a/pkg/option/value.go
+++ b/pkg/option/value.go
@@ -10,6 +10,7 @@ type (
 	}
 	valueOption[T any] struct {
 		Option
+
 		id any
 		v  T
 	}

--- a/pkg/rfc7523/anthropic.go
+++ b/pkg/rfc7523/anthropic.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Riptides Labs, Inc.
+// SPDX-License-Identifier: MIT
+
+package rfc7523
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	"go.riptides.io/tokenex/pkg/option"
+	"go.riptides.io/tokenex/pkg/token"
+)
+
+const anthropicTokenEndpoint = "https://api.anthropic.com/v1/oauth/token"
+
+// AnthropicWIFConfig holds the Anthropic-specific fields required for Workload Identity Federation.
+// See https://platform.claude.com/docs/en/manage-claude/workload-identity-federation
+type AnthropicWIFConfig struct {
+	FederationRuleID string
+	OrganizationID   string
+	ServiceAccountID string
+	WorkspaceID      string
+}
+
+// GetAnthropicCredentials is a convenience wrapper around GetCredentials for the Anthropic WIF endpoint.
+// It sets BodyFormatJSON and injects the required Anthropic fields, accepting any additional options.
+func GetAnthropicCredentials(
+	ctx context.Context,
+	logger logr.Logger,
+	tokenProvider token.IdentityTokenProvider,
+	wif AnthropicWIFConfig,
+	opts ...option.Option,
+) (<-chan Credential, error) {
+	p, err := NewCredentialsProvider(ctx, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	anthropicOpts := []option.Option{
+		WithBodyFormat(BodyFormatJSON),
+		WithAdditionalFields(map[string]string{
+			"federation_rule_id": wif.FederationRuleID,
+			"organization_id":    wif.OrganizationID,
+			"service_account_id": wif.ServiceAccountID,
+			"workspace_id":       wif.WorkspaceID,
+		}),
+	}
+
+	return p.GetCredentials(ctx, anthropicTokenEndpoint, tokenProvider, append(anthropicOpts, opts...)...)
+}

--- a/pkg/rfc7523/option.go
+++ b/pkg/rfc7523/option.go
@@ -16,6 +16,7 @@ type (
 	}
 	credentialsOption struct {
 		option.Option
+
 		f func(*credentialsConfig)
 	}
 )
@@ -88,4 +89,3 @@ func WithHTTPClient(client *http.Client) option.Option {
 		c.httpClient = client
 	})
 }
-

--- a/pkg/rfc7523/option.go
+++ b/pkg/rfc7523/option.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Riptides Labs, Inc.
+// SPDX-License-Identifier: MIT
+
+package rfc7523
+
+import (
+	"net/http"
+
+	"go.riptides.io/tokenex/pkg/option"
+	"go.riptides.io/tokenex/pkg/token"
+)
+
+type (
+	CredentialsOption interface {
+		Apply(*credentialsConfig)
+	}
+	credentialsOption struct {
+		option.Option
+		f func(*credentialsConfig)
+	}
+)
+
+func (o *credentialsOption) Apply(c *credentialsConfig) {
+	o.f(c)
+}
+
+func withCredentialsOption(f func(*credentialsConfig)) option.Option {
+	return &credentialsOption{option.OptionImpl{}, f}
+}
+
+func isCredentialsOption(opt any) (CredentialsOption, bool) {
+	if o, ok := opt.(*credentialsOption); ok {
+		return o, ok
+	}
+
+	return nil, false
+}
+
+// WithTokenEndpointURL sets the OAuth2 token endpoint URL.
+func WithTokenEndpointURL(tokenEndpointURL string) option.Option {
+	return withCredentialsOption(func(c *credentialsConfig) {
+		c.tokenEndpointURL = tokenEndpointURL
+	})
+}
+
+// WithTokenProvider sets the identity token provider whose JWT will be used as the assertion.
+func WithTokenProvider(tp token.IdentityTokenProvider) option.Option {
+	return withCredentialsOption(func(c *credentialsConfig) {
+		c.tokenProvider = tp
+	})
+}
+
+// WithScopes sets the OAuth2 scopes to request.
+func WithScopes(scopes []string) option.Option {
+	return withCredentialsOption(func(c *credentialsConfig) {
+		c.scopes = scopes
+	})
+}
+
+// WithAdditionalParams sets extra key→values merged into a form-encoded request body.
+// Only effective when BodyFormatForm is used (the default).
+func WithAdditionalParams(params map[string][]string) option.Option {
+	return withCredentialsOption(func(c *credentialsConfig) {
+		c.additionalParams = params
+	})
+}
+
+// WithAdditionalFields sets extra key→value pairs merged into a JSON request body.
+// Only effective when BodyFormatJSON is used.
+func WithAdditionalFields(fields map[string]string) option.Option {
+	return withCredentialsOption(func(c *credentialsConfig) {
+		c.additionalFields = fields
+	})
+}
+
+// WithBodyFormat selects the token request encoding.
+// Use BodyFormatJSON for the Anthropic WIF endpoint; BodyFormatForm (default) for standard RFC 7523 endpoints.
+func WithBodyFormat(f BodyFormat) option.Option {
+	return withCredentialsOption(func(c *credentialsConfig) {
+		c.bodyFormat = f
+	})
+}
+
+// WithHTTPClient sets a custom HTTP client for token endpoint requests.
+// Defaults to http.DefaultClient when not provided.
+func WithHTTPClient(client *http.Client) option.Option {
+	return withCredentialsOption(func(c *credentialsConfig) {
+		c.httpClient = client
+	})
+}
+

--- a/pkg/rfc7523/rfc7523.go
+++ b/pkg/rfc7523/rfc7523.go
@@ -189,13 +189,10 @@ func (cp *credentialsProvider) refreshCredentialsLoop(
 		cp.logger.V(1).Info("token sent", "expires", tok.Expiry)
 
 		if tok.Expiry.IsZero() {
-			// Token has no expiry — sleep briefly and re-check context.
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(5 * time.Second):
-				continue
-			}
+			// Token has no expiry — treat as valid until context is cancelled.
+			<-ctx.Done()
+
+			return
 		}
 
 		timeUntilExpiry := time.Until(tok.Expiry)

--- a/pkg/rfc7523/rfc7523.go
+++ b/pkg/rfc7523/rfc7523.go
@@ -1,0 +1,330 @@
+// Copyright (c) 2026 Riptides Labs, Inc.
+// SPDX-License-Identifier: MIT
+
+// Package rfc7523 implements an OAuth2 token exchange provider based on RFC 7523
+// (JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants).
+//
+// The provider accepts an identity JWT from any IdentityTokenProvider and exchanges
+// it at a token endpoint using the jwt-bearer grant type:
+//
+//	grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+//	assertion=<identity-jwt>
+//
+// The resulting OAuth2 access token is returned via a channel and automatically
+// refreshed before expiration.
+package rfc7523
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/go-logr/logr"
+	"golang.org/x/oauth2"
+
+	"go.riptides.io/tokenex/pkg/credential"
+	"go.riptides.io/tokenex/pkg/option"
+	"go.riptides.io/tokenex/pkg/token"
+	"go.riptides.io/tokenex/pkg/util"
+)
+
+const (
+	// GrantType is the OAuth2 grant type defined by RFC 7523.
+	GrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+)
+
+type (
+	Credential = credential.Result
+)
+
+// CredentialsProvider exchanges identity JWTs for OAuth2 access tokens via the
+// RFC 7523 jwt-bearer grant type.
+type CredentialsProvider interface {
+	// GetCredentials returns a channel that receives OAuth2 access tokens obtained
+	// by exchanging the JWT produced by tokenProvider at tokenEndpointURL.
+	// The channel is closed when the context is cancelled or an unrecoverable error occurs.
+	GetCredentials(ctx context.Context, tokenEndpointURL string, tokenProvider token.IdentityTokenProvider, opts ...option.Option) (<-chan Credential, error)
+}
+
+var _ CredentialsProvider = &credentialsProvider{}
+
+// BodyFormat controls how the token exchange request body is encoded.
+type BodyFormat int
+
+const (
+	// BodyFormatForm encodes the request as application/x-www-form-urlencoded (RFC 7523 default).
+	BodyFormatForm BodyFormat = iota
+	// BodyFormatJSON encodes the request as application/json (required by Anthropic WIF).
+	BodyFormatJSON
+)
+
+type credentialsConfig struct {
+	tokenEndpointURL string
+	tokenProvider    token.IdentityTokenProvider
+	scopes           []string
+	// additionalParams are extra key→values merged into a form-encoded body.
+	additionalParams map[string][]string
+	// additionalFields are extra key→value pairs merged into a JSON body.
+	additionalFields map[string]string
+	bodyFormat       BodyFormat
+	httpClient       *http.Client
+}
+
+type credentialsProvider struct {
+	logger logr.Logger
+}
+
+// NewCredentialsProvider creates a new RFC 7523 jwt-bearer credentials provider.
+func NewCredentialsProvider(ctx context.Context, logger logr.Logger) (*credentialsProvider, error) {
+	return &credentialsProvider{logger: logger}, nil
+}
+
+// GetCredentialsWithOptions implements credential.Provider using option-based configuration.
+//
+// Required options: WithTokenEndpointURL, WithTokenProvider.
+func (cp *credentialsProvider) GetCredentialsWithOptions(ctx context.Context, opts ...option.Option) (<-chan Credential, error) {
+	cfg := &credentialsConfig{}
+
+	for _, opt := range opts {
+		if o, ok := isCredentialsOption(opt); ok {
+			o.Apply(cfg)
+		}
+	}
+
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	return cp.GetCredentials(ctx, cfg.tokenEndpointURL, cfg.tokenProvider, opts...)
+}
+
+// GetCredentials exchanges identity tokens for OAuth2 access tokens at tokenEndpointURL.
+func (cp *credentialsProvider) GetCredentials(
+	ctx context.Context,
+	tokenEndpointURL string,
+	tokenProvider token.IdentityTokenProvider,
+	opts ...option.Option,
+) (<-chan Credential, error) {
+	cfg := &credentialsConfig{
+		tokenEndpointURL: tokenEndpointURL,
+		tokenProvider:    tokenProvider,
+	}
+
+	for _, opt := range opts {
+		if o, ok := isCredentialsOption(opt); ok {
+			o.Apply(cfg)
+		}
+	}
+
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	credsChan := make(chan credential.Result, 1)
+
+	go func() {
+		defer close(credsChan)
+		cp.refreshCredentialsLoop(ctx, cfg, credsChan)
+	}()
+
+	return credsChan, nil
+}
+
+func validateConfig(cfg *credentialsConfig) error {
+	if cfg.tokenEndpointURL == "" {
+		return errors.New("tokenEndpointURL is required")
+	}
+
+	if cfg.tokenProvider == nil {
+		return errors.New("tokenProvider is required")
+	}
+
+	return nil
+}
+
+func (cp *credentialsProvider) refreshCredentialsLoop(
+	ctx context.Context,
+	cfg *credentialsConfig,
+	credsChan chan credential.Result,
+) {
+	httpClient := cfg.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		identityToken, err := cfg.tokenProvider.GetToken(ctx)
+		if err != nil {
+			util.SendErrorToChannel(credsChan, errors.WrapIf(err, "could not get identity token"))
+
+			return
+		}
+
+		tok, err := exchangeToken(ctx, httpClient, cfg, identityToken.Token)
+		if err != nil {
+			util.SendErrorToChannel(credsChan, errors.WrapIf(err, "could not exchange jwt-bearer token"))
+
+			return
+		}
+
+		cred := credential.Oauth2Creds(*tok)
+
+		util.SendToChannel(credsChan, Credential{
+			Event:      credential.UpdateEventType,
+			Credential: &cred,
+		})
+
+		cp.logger.V(1).Info("token sent", "expires", tok.Expiry)
+
+		if tok.Expiry.IsZero() {
+			// Token has no expiry — sleep briefly and re-check context.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+				continue
+			}
+		}
+
+		timeUntilExpiry := time.Until(tok.Expiry)
+
+		if timeUntilExpiry <= 0 {
+			util.SendErrorToChannel(credsChan, errors.NewWithDetails("received already expired token", "expiresAt", tok.Expiry))
+
+			return
+		}
+
+		refreshBuffer := util.CalculateRefreshBuffer(timeUntilExpiry)
+		refreshTime := timeUntilExpiry - refreshBuffer
+
+		cp.logger.V(1).Info("scheduling token refresh", "refreshIn", refreshTime, "refreshBuffer", refreshBuffer, "expiresAt", tok.Expiry)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(refreshTime):
+			cp.logger.V(1).Info("refreshing token")
+		}
+	}
+}
+
+// tokenResponse is the JSON body returned by a successful token endpoint response.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int64  `json:"expires_in"`
+	Scope       string `json:"scope"`
+}
+
+// errorResponse is the JSON body returned by a token endpoint error.
+type errorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func exchangeToken(ctx context.Context, client *http.Client, cfg *credentialsConfig, assertion string) (*oauth2.Token, error) {
+	var (
+		bodyReader  *strings.Reader
+		contentType string
+	)
+
+	switch cfg.bodyFormat {
+	case BodyFormatJSON:
+		body := map[string]string{
+			"grant_type": GrantType,
+			"assertion":  assertion,
+		}
+
+		if len(cfg.scopes) > 0 {
+			body["scope"] = strings.Join(cfg.scopes, " ")
+		}
+
+		maps.Copy(body, cfg.additionalFields)
+
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, errors.WrapIf(err, "could not encode token request")
+		}
+
+		bodyReader = strings.NewReader(string(encoded))
+		contentType = "application/json"
+
+	default: // BodyFormatForm
+		params := url.Values{
+			"grant_type": {GrantType},
+			"assertion":  {assertion},
+		}
+
+		if len(cfg.scopes) > 0 {
+			params.Set("scope", strings.Join(cfg.scopes, " "))
+		}
+
+		maps.Copy(params, cfg.additionalParams)
+
+		bodyReader = strings.NewReader(params.Encode())
+		contentType = "application/x-www-form-urlencoded"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.tokenEndpointURL, bodyReader)
+	if err != nil {
+		return nil, errors.WrapIf(err, "could not build token request")
+	}
+
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.WrapIf(err, "token request failed")
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.WrapIf(err, "could not read token response body")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp errorResponse
+
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Error != "" {
+			return nil, errors.Errorf("token endpoint error %d: %s — %s", resp.StatusCode, errResp.Error, errResp.ErrorDescription)
+		}
+
+		return nil, errors.Errorf("token endpoint returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp tokenResponse
+
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, errors.WrapIf(err, "could not parse token response")
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, errors.New("token endpoint returned empty access_token")
+	}
+
+	tok := &oauth2.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+	}
+
+	if tokenResp.ExpiresIn > 0 {
+		tok.Expiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	}
+
+	return tok, nil
+}

--- a/pkg/util/gate.go
+++ b/pkg/util/gate.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 )
 
-// Gate is a synchronization primitive that can be opened and closed.
+// SyncGate is a synchronization primitive that can be opened and closed.
 // When open, calls to Wait will return immediately.
 // When closed, calls to Wait will block until it is opened.
 type SyncGate struct {

--- a/pkg/vault/creds.go
+++ b/pkg/vault/creds.go
@@ -104,7 +104,7 @@ type credentialsConfig struct {
 // credentialData holds the secret data and expiration information returned from Vault.
 type credentialData struct {
 	// Data contains the secret data retrieved from Vault.
-	Data map[string]interface{}
+	Data map[string]any
 
 	// ExpiresAt is the time when the credentials expire and should no longer be used.
 	ExpiresAt time.Time

--- a/pkg/vault/option.go
+++ b/pkg/vault/option.go
@@ -17,6 +17,7 @@ type (
 	}
 	credentialsOption struct {
 		option.Option
+
 		f func(*credentialsConfig)
 	}
 )


### PR DESCRIPTION
This pull request introduces a new RFC 7523 OAuth2 token exchange provider, adds Anthropic Workload Identity Federation (WIF) support, and makes several supporting improvements across the codebase. The most significant changes are the addition of a new `rfc7523` package for JWT-bearer token exchange, new Anthropic WIF helpers, and the introduction of option patterns for extensibility. There are also minor improvements to linter configuration, dependency versions, and code consistency.

### RFC 7523 OAuth2/JWT-Bearer Token Exchange

* Added a new `pkg/rfc7523` package implementing an RFC 7523-compliant OAuth2 token exchange provider, including the main provider logic, request/response handling, and support for both form-encoded and JSON request bodies. This enables exchanging identity JWTs for OAuth2 access tokens in a generic and extensible way.

* Introduced an options pattern for configuring the RFC 7523 provider, with helpers for token endpoint URL, token provider, scopes, additional parameters/fields, request body format, and custom HTTP clients in `pkg/rfc7523/option.go`.

### Anthropic Workload Identity Federation (WIF) Support

* Added `pkg/rfc7523/anthropic.go` with a convenience wrapper for exchanging tokens using Anthropic's WIF endpoint, including a config struct for Anthropic-specific fields and automatic JSON body formatting.

### Codebase Consistency and Minor Improvements

* Added missing blank lines in the definition of `credentialsOption` in multiple provider `option.go` files for consistency. [[1]](diffhunk://#diff-f118d8e1cef61bd062424a599cb13593c3b57c8911c80b6324339e88560576f2R18) [[2]](diffhunk://#diff-4b724a8cff4f543d3d1f04af29a9edb464a1e84691e70f0ac15be169869b7632R18) [[3]](diffhunk://#diff-d807bf65dafb0579c245a2f16c452e2f3938a80885f2dd7cbd1df8f9138c2691R20) [[4]](diffhunk://#diff-707fc64cd645ce3797598ce64e3c2ce77ad804f98f000134c50fa6187f01c205R20) [[5]](diffhunk://#diff-7064a7af2e77202a16441c229788d9906b176cfd83994165f80b681068fcab8aR15) [[6]](diffhunk://#diff-6aba23c2f5b59ae4babd6bfaa7ab7a394cb10d191254ec7385c771aed6fb60e6R19) [[7]](diffhunk://#diff-9690dcd668a6848c60938cf8ea6ac64dfac11fac8576fb002a3f7b10774f96a1R18) [[8]](diffhunk://#diff-6ebdd15dc5ec23f7120bfbedd04480eeeecc163af8baa566d19094074deff202R20) [[9]](diffhunk://#diff-169a557baf4879212a2805da07da4d3abc3ad77adad30b75a0f863a0bd0ba1bcR13)
* Changed the type of the `Data` field in `pkg/vault/creds.go` from `map[string]interface{}` to `map[string]any` for idiomatic Go usage.
* Renamed the comment for `SyncGate` in `pkg/util/gate.go` to match the type name.

### Linter and Dependency Updates

* Updated `.golangci.yaml` to enable new linters: `funcorder`, `wsl_v5`, and `noinlineerr`.
* Bumped `GOLANGCI_VERSION` from 2.0.2 to 2.9.0 in the `Makefile` for newer linter support.

### Miscellaneous

* Minor code formatting and import grouping improvements, e.g., in `pkg/gcp/sts.go`.