### PR TITLE
Add Provider marker interface and GetCredentialsWithOptions

### DIFF
--- a/pkg/rfc7523/rfc7523.go
+++ b/pkg/rfc7523/rfc7523.go
@@ -43,6 +43,12 @@ type (
 	Credential = credential.Result
 )
 
+type Provider interface {
+	isRFC7523Provider()
+}
+
+func (cp *credentialsProvider) isRFC7523Provider() {}
+
 // CredentialsProvider exchanges identity JWTs for OAuth2 access tokens via the
 // RFC 7523 jwt-bearer grant type.
 type CredentialsProvider interface {

--- a/pkg/rfc8693/rfc8693.go
+++ b/pkg/rfc8693/rfc8693.go
@@ -52,6 +52,12 @@ type (
 	Credential = credential.Result
 )
 
+type Provider interface {
+	isRFC8693Provider()
+}
+
+func (cp *credentialsProvider) isRFC8693Provider() {}
+
 type CredentialsProvider interface {
 	GetCredentials(ctx context.Context, tokenEndpointURL string, subjectTokenProvider token.IdentityTokenProvider, opts ...option.Option) (<-chan Credential, error)
 }
@@ -77,6 +83,25 @@ type credentialsProvider struct {
 
 func NewCredentialsProvider(_ context.Context, logger logr.Logger) (*credentialsProvider, error) {
 	return &credentialsProvider{logger: logger}, nil
+}
+
+// GetCredentialsWithOptions implements credential.Provider using option-based configuration.
+//
+// Required options: WithTokenEndpointURL, WithTokenProvider.
+func (cp *credentialsProvider) GetCredentialsWithOptions(ctx context.Context, opts ...option.Option) (<-chan Credential, error) {
+	cfg := &credentialsConfig{}
+
+	for _, opt := range opts {
+		if o, ok := isCredentialsOption(opt); ok {
+			o.Apply(cfg)
+		}
+	}
+
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	return cp.GetCredentials(ctx, cfg.tokenEndpointURL, cfg.subjectTokenProvider, opts...)
 }
 
 func (cp *credentialsProvider) GetCredentials(


### PR DESCRIPTION
This pull request introduces new provider interfaces and extends the credentials provider functionality in both the `rfc7523` and `rfc8693` packages. The main goals are to improve type safety and enable option-based configuration for credential retrieval.

### Provider interface additions

* Added a new `Provider` interface with a marker method `isRFC7523Provider()` to the `rfc7523` package, and implemented this method in the `credentialsProvider` type.
* Added a new `Provider` interface with a marker method `isRFC8693Provider()` to the `rfc8693` package, and implemented this method in the `credentialsProvider` type.

### Credentials provider enhancements

* Introduced a new `GetCredentialsWithOptions` method to `credentialsProvider` in the `rfc8693` package, supporting option-based configuration for credential retrieval and improving flexibility in how credentials are requested.