### PR TITLE
fix(oauth2ac): don't signal spurious refresh on first authorization

### DIFF
--- a/pkg/oauth2ac/oauth2ac.go
+++ b/pkg/oauth2ac/oauth2ac.go
@@ -288,7 +288,8 @@ func (cp *credentialsProvider) Start(ctx context.Context) (<-chan StatusEvent, e
 }
 
 func (cp *credentialsProvider) Authorize(ctx context.Context, authState, code string) (*oauth2.Token, error) {
-	if !cp.reauthorizeIfAuthorized && cp.syncGate.IsOpen() {
+	wasAuthorized := cp.syncGate.IsOpen()
+	if !cp.reauthorizeIfAuthorized && wasAuthorized {
 		return nil, errors.WithStack(ErrAlreadyAuthorized)
 	}
 
@@ -315,7 +316,7 @@ func (cp *credentialsProvider) Authorize(ctx context.Context, authState, code st
 	cp.authorizeSpanContext = sc
 	cp.mu.Unlock()
 
-	if cp.syncGate.IsOpen() {
+	if wasAuthorized {
 		cp.signalRefresh()
 	}
 


### PR DESCRIPTION
## Summary
- `Authorize` checked `syncGate.IsOpen()` both before and after `storeTokenAndAuthorize`, but that call opens the gate as a side effect (via `setAuthorizedStatus`), so the post-check always read `true` — even on the very first authorization.
- This caused `signalRefresh()` to fire spuriously on first-time auth, making `tokenRefresherLoop` immediately replace the token it just published and emit a bogus `RemoveEventType` credential event right after the initial `Update`.
- Fix: capture `syncGate.IsOpen()` once before the token is stored, and use that captured value for both the early-return check and the post-store refresh-signal decision, so refresh is only signaled on genuine re-authorization.